### PR TITLE
add func from map scenario and expected format

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -263,6 +263,24 @@ func crawlExprSelectorChain(pass *analysis.Pass, sel ast.Expr) []string {
 		return []string{ident.Name}
 	}
 
+	basicLit, ok := sel.(*ast.BasicLit)
+	if ok {
+		return []string{basicLit.Value}
+	}
+
+	indexExpr, ok := sel.(*ast.IndexExpr)
+	if ok {
+		indexExprIndex := crawlExprSelectorChain(pass, indexExpr.Index)
+		indexExprs := append(crawlExprSelectorChain(pass, indexExpr.X), indexExprIndex...)
+		for i := range indexExprs {
+			indexExprs[i] = strings.Replace(indexExprs[i], "\"", "", -1)
+			if i != 0 {
+				indexExprs[i] = fmt.Sprintf("[%s]", indexExprs[i])
+			}
+		}
+		return []string{strings.Join(indexExprs, "")}
+	}
+
 	return nil
 }
 

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -15,6 +15,7 @@ func TestAll(t *testing.T) {
 		{name: "different package method", packageName: "differentpkgmethod"},
 		{name: "error not wrapped", packageName: "errnotwrapped"},
 		{name: "func from getter", packageName: "funcfromgetter"},
+		{name: "func from map", packageName: "funcfrommap"},
 		{name: "func from nested getter", packageName: "funcfromnestedgetter"},
 		{name: "func literal", packageName: "funcliteral"},
 		{name: "interface method", packageName: "interfacemethod"},

--- a/testdata/src/funcfrommap/func_from_map.go
+++ b/testdata/src/funcfrommap/func_from_map.go
@@ -1,0 +1,49 @@
+package funcfrommap
+
+import (
+	"fmt"
+)
+
+type stadium struct{}
+
+func (s stadium) Play() error {
+	return nil
+}
+
+func okFormat() error {
+	allStadiums := map[string]stadium{
+		"Cambridge": {},
+	}
+	err := allStadiums["Cambridge"].Play()
+	if err != nil {
+		return fmt.Errorf("allStadiums[Cambridge].Play: %w", err)
+	}
+
+	return nil
+}
+
+func okFormatNested() error {
+	allVenues := map[string]map[string]stadium{
+		"stadiums": {
+			"Cambridge": {},
+		},
+	}
+	err := allVenues["stadiums"]["Cambridge"].Play()
+	if err != nil {
+		return fmt.Errorf("allVenues[stadiums][Cambridge].Play: %w", err)
+	}
+
+	return nil
+}
+
+func badFormat() error {
+	allStadiums := map[string]stadium{
+		"Cambridge": {},
+	}
+	err := allStadiums["Cambridge"].Play()
+	if err != nil {
+		return fmt.Errorf("Play: %w", err) // want `error message not prefixed in expected format`
+	}
+
+	return nil
+}


### PR DESCRIPTION
Resolves https://github.com/tomhutch/errfmt/issues/1

These changes define the expected format for when an error is wrapped for a method called from a value retrieved from a map, for example:
```
err := allStadiums["Cambridge"].Play()
if err != nil {
      return fmt.Errorf("allStadiums[Cambridge].Play: %w", err)
}
```