### PR TITLE
handle mixed map and struct attr syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 test:
-	go test -count=1 ./core/... -v
+	go test -count=1 ./... -v
 
 .PHONY: install
 install:

--- a/testdata/src/funcfrommap/func_from_map.go
+++ b/testdata/src/funcfrommap/func_from_map.go
@@ -22,6 +22,23 @@ func okFormat() error {
 	return nil
 }
 
+func okFormatMapAttribute() error {
+	allStadiums := map[string]stadium{
+		"Cambridge": {},
+	}
+	allVenues := struct {
+		stadiums map[string]stadium
+	}{
+		stadiums: allStadiums,
+	}
+	err := allVenues.stadiums["Cambridge"].Play()
+	if err != nil {
+		return fmt.Errorf("allVenues.stadiums[Cambridge].Play: %w", err)
+	}
+
+	return nil
+}
+
 func okFormatNested() error {
 	allVenues := map[string]map[string]stadium{
 		"stadiums": {


### PR DESCRIPTION
These changes fix an issue with the handling of error messages from functions retrieved with maps. When a call chain includes a mix of selector expressions and index expressions then the linter currently assumes we have index expressions all the way down. This fix makes it so any index expression indexes are formatted and appended to the end of the index expression recursively - allowing for linting for error messages like this:
```
err := allVenues.stadiums["Cambridge"].Play()
if err != nil {
	return fmt.Errorf("allVenues.stadiums[Cambridge].Play: %w", err)
}
```